### PR TITLE
Add missing invalid items and correct the hint logic hierarchy

### DIFF
--- a/List/LocationList.py
+++ b/List/LocationList.py
@@ -402,7 +402,7 @@ class Locations:
             KH2Treasure(269, "00 Ice Cream", LocationTypes=[locationType.HB], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
             KH2Treasure(511, "00 Picture", LocationTypes=[locationType.HB], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(367, "00 Undersea Kingdom Map", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(367, "00 Undersea Kingdom Map", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.TORN_PAGE, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
             KH2Treasure(270, "00 Rumbling Rose", LocationTypes=[locationType.BC], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
             KH2Treasure(325, "00 Castle Walls Map", LocationTypes=[locationType.BC], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
@@ -421,9 +421,9 @@ class Locations:
             KH2Treasure(298, "00 Decoy Presents", LocationTypes=[locationType.HT], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
             KH2Treasure(275, "00 Decisive Pumpkin", LocationTypes=[locationType.HT], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(287, "00 Mysterious Abyss", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
-            KH2Treasure(279, "00 Blizzard Element", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
-            KH2Treasure(538, "00 Orichalcum+", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.FORM,itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(287, "00 Mysterious Abyss", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.TORN_PAGE, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(279, "00 Blizzard Element", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.TORN_PAGE, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(538, "00 Orichalcum+", LocationTypes=[locationType.Atlantica], InvalidChecks=[itemType.MAGNET, itemType.THUNDER, itemType.TORN_PAGE, itemType.FORM, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
             KH2Treasure(284, "00 Sweet Memories", LocationTypes=[locationType.HUNDREDAW], InvalidChecks=[itemType.TORN_PAGE,itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
             KH2Treasure(485, "00 Spooky Cave Map", LocationTypes=[locationType.HUNDREDAW], InvalidChecks=[itemType.TORN_PAGE,itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
@@ -506,13 +506,13 @@ class Locations:
 
             KH2Treasure(558, "00 Magic Boost", LocationTypes=[locationType.STT, locationType.DataOrg], InvalidChecks=[itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(587, "00 Proof of Connection", LocationTypes=[locationType.DC, locationType.LW], InvalidChecks=[itemType.PROOF_OF_CONNECTION, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(587, "00 Proof of Connection", LocationTypes=[locationType.DC, locationType.LW], InvalidChecks=[itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.TORN_PAGE, itemType.PROOF_OF_CONNECTION, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(591, "00 Manifest Illusion", LocationTypes=[locationType.DC, locationType.LW], InvalidChecks=[itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.PROOF_OF_CONNECTION, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(591, "00 Manifest Illusion", LocationTypes=[locationType.DC, locationType.LW], InvalidChecks=[itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.TORN_PAGE, itemType.PROOF_OF_CONNECTION, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(588, "00 Winner's Proof", LocationTypes=[locationType.HB], InvalidChecks=[itemType.PROOF_OF_PEACE, itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
+            KH2Treasure(588, "00 Winner's Proof", LocationTypes=[locationType.HB], InvalidChecks=[itemType.PROOF_OF_PEACE, itemType.TORN_PAGE, itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY]),
 
-            KH2Treasure(589, "00 Proof of Peace", LocationTypes=[locationType.HB], InvalidChecks=[itemType.PROOF_OF_PEACE, itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY])
+            KH2Treasure(589, "00 Proof of Peace", LocationTypes=[locationType.HB], InvalidChecks=[itemType.PROOF_OF_PEACE, itemType.TORN_PAGE, itemType.FORM, itemType.THUNDER, itemType.MAGNET, itemType.GROWTH_ABILITY, itemType.SUPPORT_ABILITY, itemType.ACTION_ABILITY])
         ]
 
     def getSoraLevelList():

--- a/Module/hints.py
+++ b/Module/hints.py
@@ -1,6 +1,8 @@
 from List.configDict import itemType, locationType
-from Class.locationClass import KH2ItemStat
+from Class.locationClass import KH2ItemStat,KH2Treasure
 import zipfile, base64, json, random
+from itertools import permutations
+
 
 class Hints:
     def generateHints(locationItems, hintsType, seedName, outZip):
@@ -18,9 +20,18 @@ class Hints:
                     hintsText['world'][location.LocationTypes[0]].append(item.Name)
 
         if hintsType == "JSmartee":
+            proof_of_connection_index = None
+            proof_of_peace_index = None
             hintedWorlds = []
             reportsList = list(range(1,14))
+            # different possibilities for how to make the reports hinting the proofs hinted
+            temp_ordering = permutations(reportsList, 3)
+            reportOrdering = []
+            for o in temp_ordering:
+                reportOrdering.append(o)
             hintsText['Reports'] = {}
+            isReportOnMushroom = [False for x in range(13)]
+            isReportOnTerra = [False for x in range(13)]
             importantChecks = [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.REFLECT, itemType.MAGNET, itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.FORM, itemType.TORN_PAGE, itemType.SUMMON, itemType.REPORT, "Second Chance", "Once More"]
             worldChecks = {}
             for location,item in locationItems:
@@ -32,50 +43,93 @@ class Hints:
                     worldChecks[location.LocationTypes[0]].append(item)
                     if item.ItemType in [itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE]:
                         if not location.LocationTypes[0] in hintedWorlds:
+                            if item.ItemType is itemType.PROOF_OF_CONNECTION:
+                                proof_of_connection_index = len(hintedWorlds)
+                            if item.ItemType is itemType.PROOF_OF_PEACE:
+                                proof_of_peace_index = len(hintedWorlds)
                             hintedWorlds.append(location.LocationTypes[0])
+                        else:
+                            if item.ItemType is itemType.PROOF_OF_CONNECTION:
+                                proof_of_connection_index = hintedWorlds.index(location.LocationTypes[0])
+                            if item.ItemType is itemType.PROOF_OF_PEACE:
+                                proof_of_peace_index = hintedWorlds.index(location.LocationTypes[0])
+                    if item.ItemType is itemType.REPORT:
+                        reportNumber = int(item.Name.replace("Secret Ansem's Report ",""))
+                        if locationType.LW in location.LocationTypes:
+                            isReportOnTerra[reportNumber] = True
+                        if isinstance(location,KH2Treasure) and location.Description in ["00 Winner's Proof","00 Proof of Peace"]:
+                            isReportOnMushroom[reportNumber] = True
+
 
             if len(worldChecks.keys()) < 13:
                 raise ValueError("Too few worlds. Add more worlds or change hint system.")
 
+            forms_need_hints = (locationType.FormLevel in hintedWorlds)
+            pages_need_hints = (locationType.HUNDREDAW in hintedWorlds)
+            mag_thun_need_hints = (locationType.Atlantica in hintedWorlds)
 
-            if locationType.FormLevel in hintedWorlds:
+            # following the priority of Proofs > Forms > Pages > Thunders > Magnets > Proof Reports
+            if forms_need_hints:
                 for world in worldChecks:
                     if not world in hintedWorlds and any(item.ItemType == itemType.FORM for item in worldChecks[world]):
                         hintedWorlds.append(world)
 
 
-            if locationType.HUNDREDAW in hintedWorlds:
+            if pages_need_hints:
                 for world in worldChecks:
                     if not world in hintedWorlds and any(item.ItemType == itemType.TORN_PAGE for item in worldChecks[world]):
                         hintedWorlds.append(world)
 
 
-            if locationType.Atlantica in hintedWorlds:
+            if mag_thun_need_hints:
                 for world in worldChecks:
-                    if not world in hintedWorlds and any(item.ItemType == itemType.THUNDER or item.ItemType == itemType.MAGNET for item in worldChecks[world]):
+                    if not world in hintedWorlds and any(item.ItemType == itemType.THUNDER for item in worldChecks[world]):
                         hintedWorlds.append(world)
 
-
-            for world in hintedWorlds:
-                random.shuffle(reportsList)
-                reportNumber = reportsList.pop()
-                hintsText["Reports"][reportNumber] = {
-                    "World": world,
-                    "Count": len(worldChecks[world]),
-                    "Location": ""
-                }
-
-            hintedHints = []
-
-            for reportNumber in hintsText["Reports"].keys():
+            if mag_thun_need_hints:
                 for world in worldChecks:
-                    if not world in hintedWorlds and not world in hintedHints and any(item.Name.replace("Secret Ansem's Report ","") == str(reportNumber) for item in worldChecks[world] ):
-                        hintedHints.append(world)
-                        hintsText["Reports"][reportNumber]["Location"] = world
+                    if not world in hintedWorlds and any(item.ItemType == itemType.MAGNET for item in worldChecks[world]):
+                        hintedWorlds.append(world)
 
-            for world in hintedHints:
-                random.shuffle(reportsList)
-                reportNumber = reportsList.pop()
+            # hintedWorlds is now all the required hinted worlds. We'll see if we can also hint the reports that hint proofs
+            if len(hintedWorlds) > 13:
+                hintedWorlds = hintedWorlds[0:13]
+
+            random.shuffle(reportOrdering)
+            proof_report_order = None
+            for ordering in reportOrdering:
+                remaining_report_slots = 13-len(hintedWorlds)
+                worlds_to_add = []
+                for index,reportNumber in enumerate(ordering):
+                    invalid = False
+                    for world in worldChecks:
+                        if any(item.Name.replace("Secret Ansem's Report ","") == str(reportNumber) for item in worldChecks[world] ):
+                            #don't allow a report for a proof to be locked by that proof
+                            if (proof_of_peace_index is index and isReportOnMushroom[reportNumber]) or \
+                               (proof_of_connection_index is index and isReportOnTerra[reportNumber]):
+                                invalid = True
+                                break
+                            if world not in hintedWorlds:
+                                # totally fine if we have space
+                                worlds_to_add.append(world)
+                                remaining_report_slots-=1
+                                break
+                    if invalid:
+                        break
+                if remaining_report_slots >= 0:
+                    proof_report_order = ordering
+                    hintedWorlds+=worlds_to_add
+                    break
+
+            # ------------------ Done filling required hinted worlds --------------------------------
+
+            for index,world in enumerate(hintedWorlds):
+                if index < 3 and proof_report_order is not None:
+                    reportNumber = proof_report_order[index]
+                    reportsList.remove(reportNumber)
+                else:
+                    random.shuffle(reportsList)
+                    reportNumber = reportsList.pop()
                 hintsText["Reports"][reportNumber] = {
                     "World": world,
                     "Count": len(worldChecks[world]),
@@ -87,7 +141,7 @@ class Hints:
                 worlds = list(worldChecks.keys())
                 random.shuffle(worlds)
                 randomWorld = None
-                if not worlds[0] in hintedWorlds and not worlds[0] in hintedHints:
+                if not worlds[0] in hintedWorlds:
                     randomWorld = worlds[0]
                 else:
                     continue
@@ -107,14 +161,6 @@ class Hints:
                 for world in worldChecks:
                     if any(item.Name.replace("Secret Ansem's Report ","") == str(reportNumber) for item in worldChecks[world] ):
                         hintsText["Reports"][reportNumber]["Location"] = world
-
-
-
-            
-
-
-
-
 
         outZip.writestr("{seedName}.Hints".format(seedName = seedName), base64.b64encode(json.dumps(hintsText).encode('utf-8')).decode('utf-8'))
 


### PR DESCRIPTION
- While prepping a potential logic feature for the generator, I noticed some missing invalid items for Atlantica, Terra, and Mushroom. 
- The hint logic was incorrectly making worlds required to be hinted due to the cascading addition into the `hintedWorlds` variable. 
- Added the logic for hints that point to proofs can't be on a location locked by that proof (e.g. report on Mushroom that hints the Proof of Peace)

Please feel free to comment if there is something that would make it easier/preferable for this change to get merged in.