### PR TITLE
Enabling promise charm to be in item pool, and checking for it in hints

### DIFF
--- a/Module/hints.py
+++ b/Module/hints.py
@@ -9,7 +9,7 @@ class Hints:
         hintsText = {}
         hintsText['hintsType'] = hintsType
         if hintsType == "Shananas":
-            importantChecks = [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.REFLECT, itemType.MAGNET, itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.FORM, itemType.TORN_PAGE, itemType.SUMMON]
+            importantChecks = [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.REFLECT, itemType.MAGNET, itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.PROMISE_CHARM, itemType.FORM, itemType.TORN_PAGE, itemType.SUMMON]
             hintsText['world'] = {}
             for location,item in locationItems:
                 if isinstance(location, KH2ItemStat):
@@ -32,7 +32,7 @@ class Hints:
             hintsText['Reports'] = {}
             isReportOnMushroom = [False for x in range(13)]
             isReportOnTerra = [False for x in range(13)]
-            importantChecks = [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.REFLECT, itemType.MAGNET, itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.FORM, itemType.TORN_PAGE, itemType.SUMMON, itemType.REPORT, "Second Chance", "Once More"]
+            importantChecks = [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.REFLECT, itemType.MAGNET, itemType.PROOF, itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.PROMISE_CHARM, itemType.FORM, itemType.TORN_PAGE, itemType.SUMMON, itemType.REPORT, "Second Chance", "Once More"]
             worldChecks = {}
             for location,item in locationItems:
                 if isinstance(location, KH2ItemStat) or location.LocationTypes[0] == locationType.Free or location.LocationTypes[0] == locationType.Critical:

--- a/Module/randomize.py
+++ b/Module/randomize.py
@@ -63,7 +63,7 @@ class KH2Randomizer():
         self._validItemListGoofy = Items.getGoofyAbilityList()
         self._validItemListDonald = Items.getDonaldAbilityList()
         if promiseCharm:
-            self._validItemList.append(KH2Item(524, "Promise Charm",itemType.PROMISE_CHARM))
+            validItemList.append(KH2Item(524, "PromiseCharm",itemType.PROMISE_CHARM))
 
         self._validItemList = [item for item in validItemList if not str(item.Id) in startingInventory]
 


### PR DESCRIPTION
Fixes #27 

Exposes a potential inconsistency with KHTracker where Shananas hints with promise charm enabled cause hints to not load. May require additional changes to address that.