### PR TITLE
Joattpresets

### DIFF
--- a/static/js/preset.js
+++ b/static/js/preset.js
@@ -215,7 +215,7 @@ const presets = {
         "levelChoice":"Level",
         "keybladeMinStat":0,
         "keybladeMaxStat":7,
-        "SoraExp":0,
+        "SoraExp":1,
         "ValorExp":5,
         "WisdomExp":5,
         "LimitExp":5,
@@ -225,7 +225,7 @@ const presets = {
         "enemy":"Disabled",
         "hintsType":"Shananas",
         "PromiseCharm":[false],
-        "starting-inventory":["No Experience"]
+        "starting-inventory":["404"]
     },
     "Bingo":{
         "include":[

--- a/static/js/preset.js
+++ b/static/js/preset.js
@@ -173,7 +173,6 @@ const presets = {
             "locationType.DC",
             "locationType.HUNDREDAW",
             "locationType.STT",
-            "locationType.Atlantica",
             "locationType.FormLevel",
             "locationType.Free",
             "locationType.AS"
@@ -192,6 +191,41 @@ const presets = {
         "hintsType":"Shananas",
         "PromiseCharm":[false],
         "starting-inventory":[]
+    },
+    "Level 1":{
+        "include":[
+            "locationType.LoD",
+            "locationType.BC",
+            "locationType.HB",
+            "locationType.CoR",
+            "locationType.TT",
+            "locationType.TWTNW",
+            "locationType.SP",
+            "locationType.PR",
+            "locationType.OC",
+            "locationType.Agrabah",
+            "locationType.HT",
+            "locationType.PL",
+            "locationType.DC",
+            "locationType.HUNDREDAW",
+            "locationType.STT",
+            "locationType.FormLevel",
+            "locationType.Free",
+        ],
+        "levelChoice":"Level",
+        "keybladeMinStat":0,
+        "keybladeMaxStat":7,
+        "SoraExp":0,
+        "ValorExp":5,
+        "WisdomExp":5,
+        "LimitExp":5,
+        "MasterExp":5,
+        "FinalExp":5,
+        "keybladeAbilities":["Support"],
+        "enemy":"Disabled",
+        "hintsType":"Shananas",
+        "PromiseCharm":[false],
+        "starting-inventory":["No Experience"]
     },
     "Bingo":{
         "include":[
@@ -217,7 +251,7 @@ const presets = {
             "locationType.Free",
             "locationType.Critical"
         ],
-        "levelChoice":"ExcludeFrom50",
+        "levelChoice":"Level",
         "keybladeMinStat":3,
         "keybladeMaxStat":10,
         "SoraExp":2.5,
@@ -273,7 +307,46 @@ const presets = {
         "PromiseCharm":[false],
         "starting-inventory":["593","594","595"]
     },
-
-
-
+    "Better All Blue Numbers":{
+        "include":[
+            "locationType.LoD",
+            "locationType.BC",
+            "locationType.HB",
+            "locationType.TT",
+            "locationType.TWTNW",
+            "locationType.SP",
+            "locationType.PR",
+            "locationType.OC",
+            "locationType.Agrabah",
+            "locationType.HT",
+            "locationType.PL",
+            "locationType.DC",
+            "locationType.HUNDREDAW",
+            "locationType.STT",
+            "locationType.AS",
+            "locationType.Sephi",
+            "locationType.FormLevel",
+            "locationType.Free",
+            "locationType.Critical",
+            "locationType.Atlantica",
+            "locationType.LW",
+            "locationType.DataOrg"
+        ],
+        "levelChoice":"ExcludeFrom99",
+        "keybladeMinStat":5,
+        "keybladeMaxStat":13,
+        "SoraExp":7,
+        "ValorExp":10,
+        "WisdomExp":7,
+        "LimitExp":7,
+        "MasterExp":7,
+        "FinalExp":7,
+        "SummonExp":5,
+        "keybladeAbilities":["Support", "Action"],
+        "enemy":"Disabled",
+        "hintsType":"Shananas",
+        "PromiseCharm":[true],
+        "starting-inventory":[],
+        "seedModifiers": ["Schmovement", "Better Junk"]
+    }
 };


### PR DESCRIPTION
adds
Better All Blue Numbers
Level 1

updates
beginner to disclude Atlantica, to match the last Beginner Blitz ruleset. In order to actually match Beginner Blitz, a feature will need to be added to force reports to be found during first visits, so for now this is not exactly "Beginner Blitz"