### PR TITLE
Fix 404 upon seed generation on Firefox

### DIFF
--- a/templates/seed.jinja
+++ b/templates/seed.jinja
@@ -79,12 +79,13 @@
 </div> 
 
 </div>
+</form>
 
 <div id="downloadButtons">
 <button id="PCSX2" name="platform" value="PCSX2">Generate for PCSX2</button>
 <button id="PC" name="platform" value="PC">Generate for PC (beta)</button> <a href="https://github.com/tommadness/KH2Randomizer/blob/master/helpinfo/pc.md">PC Setup Instructions</a>
 </div>
-</form>
+
 <script>
 
 $(document).ready(function(){


### PR DESCRIPTION
Resolves #42

Having the generate `button`s inside the `form` on the seed page would cause Firefox to get confused in the click event handler and navigate directly to `/download` instead of sending a websocket message when it reaches `socket.emit('download')`.

I actually have no idea how this works at all and it seems so incredibly stupid but at least we've found the issue.

It's not the best practice having these buttons outside the form but oh well.

(Regression introduced in 868d2dd0b4eddb1b78baf55f6c4023537c327916)