### PR TITLE
Fix generating seeds on Firefox

### DIFF
--- a/templates/seed.jinja
+++ b/templates/seed.jinja
@@ -94,7 +94,7 @@ $(document).ready(function(){
 });
 
 $(function(){
-    $('button').click(function(){
+    $('button').click(function(ev){
         var platform = $(this).val();
         var cmdMenuChoice = $("select[name=cmdMenuChoice]").val();
         var randomBGM = $("select[name=randomBGM]").val();
@@ -110,6 +110,7 @@ $(function(){
             saveAs(blob, "randoseed.zip");
             socket.disconnect();
         });
+        ev.preventDefault();
     });
 });
 


### PR DESCRIPTION
Resolves #42

In Firefox, clicking a `button` inside a `form` without `preventDefault()` in the event handler triggers the `form` action. In this case, it caused the browser to navigate to `/download`, leading to a 404. By calling `preventDefault()` on the event, it prevents Firefox from performing this action and letting the websocket message go through.

Thanks to @auscompgeek for finding the cause.

(Regression introduced in 868d2dd when moving the buttons inside the form)