### PR TITLE
Adding an option to prevent the self hinting of reports

### DIFF
--- a/Module/hints.py
+++ b/Module/hints.py
@@ -5,7 +5,7 @@ from itertools import permutations
 
 
 class Hints:
-    def generateHints(locationItems, hintsType, seedName, excludeList):
+    def generateHints(locationItems, hintsType, seedName, excludeList, preventSelfHinting=True):
         if hintsType=="Disabled":
             return None
         hintsText = {}
@@ -69,7 +69,8 @@ class Hints:
                 if item.ItemType is itemType.REPORT:
                     reportNumber = int(item.Name.replace("Secret Ansem's Report ",""))
                     #report can't hint itself
-                    reportRestrictions[reportNumber-1].append(location.LocationTypes[0])
+                    if preventSelfHinting:
+                        reportRestrictions[reportNumber-1].append(location.LocationTypes[0])
                     if locationType.LW in location.LocationTypes:
                         # if report on LW, can't hint world that contains proof of connection
                         reportRestrictions[reportNumber-1].append(worldsToHint[proof_of_connection_index])
@@ -192,7 +193,7 @@ class Hints:
             if len(hintsText["Reports"])==0:
                 return "Unable to find valid assignment for hints..."
 
-            # slack worlds to hint, can point to anywhere as long as they don't self hint
+            # slack worlds to hint, can point to anywhere
             while len(reportsList) > 0:
                 random.shuffle(reportsList)
                 worlds = list(worldChecks.keys())

--- a/app.py
+++ b/app.py
@@ -132,6 +132,8 @@ def seed():
         else:
             session['reportDepth'] = locationDepth(hintSubstrings[1])
 
+        session['preventSelfHinting'] = bool(fl.request.form.get("preventSelfHinting") or False)
+
         session['startingInventory'] = fl.request.form.getlist("startingInventory")
 
         session['itemPlacementDifficulty'] = fl.request.form.get("itemPlacementDifficulty")
@@ -162,6 +164,7 @@ def seed():
     enemyOptions = json.loads(session.get("enemyOptions")),
     hintsType = session.get("hintsType"),
     reportDepth = session.get("reportDepth"),
+    preventSelfHinting = session.get("preventSelfHinting"),
     startingInventory = session.get("startingInventory"),
     itemPlacementDifficulty = session.get("itemPlacementDifficulty"),
     seedModifiers = session.get("seedModifiers"),
@@ -212,7 +215,7 @@ def randomizePage(data, sessionDict):
                 continue
             notValidSeed = False
             randomizer.seedName = originalSeedName
-            hintsText = Hints.generateHints(randomizer._locationItems, sessionDict["hintsType"], randomizer.seedName, excludeList)
+            hintsText = Hints.generateHints(randomizer._locationItems, sessionDict["hintsType"], randomizer.seedName, excludeList, sessionDict["preventSelfHinting"])
 
             if hintsText is not None and type(hintsText) is not dict:
                 # there was an error generating hints, return value provides context

--- a/static/js/preset.js
+++ b/static/js/preset.js
@@ -385,6 +385,7 @@ const presets = {
         "keybladeAbilities":["Support"],
         "enemy":"Disabled",
         "hintsType":"JSmartee-SecondVisit",
+        "preventSelfHinting":"False",
         "PromiseCharm":[false],
         "starting-inventory":["138"]
     },

--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -88,6 +88,11 @@
                     <option value={{option}}>{{option}}</option>
                 {%endfor%}
             </select>
+            <div>
+            <label for="preventSelfHinting" data-toggle="tooltip" data-placement="top" title="Prevent reports from hinting the world where a report is found">Jsmartee Only: No self-hinting reports</label> 
+            <label class="switch"><input type="checkbox" checked name="preventSelfHinting" value="True" id="preventSelfHinting"/><span class="slider round">
+            </label>
+            </div>
         </div>
         <div class="vertical top">
             <h4>Sora's Starting Inventory</h4>

--- a/templates/seed.jinja
+++ b/templates/seed.jinja
@@ -45,7 +45,7 @@
 </div>
 
 <div class="container">
-    <div class="vertical top"><h5>Hint System</h5>{{hintsType}}</div>
+    <div class="vertical top"><h5>Hint System</h5>{{hintsType}}<h6>Jsmartee only: Prevent Self Hinting</h6>{{preventSelfHinting}}</div>
     <div class="vertical top"><h5>Starting Inventory</h5>{%for item in startingInventory%}{{idConverter[item]}}<br>{%endfor%}</div>
     <div class="vertical top"><h5>Item Placement Difficulty</h5>{{itemPlacementDifficulty}}</div>
     <div class="vertical top"><h5>Seed Modifiers</h5>{%for modifier in seedModifiers%}{{modifier}}<br>{%endfor%}</div>

--- a/tests/test_jsmarteeHints.py
+++ b/tests/test_jsmarteeHints.py
@@ -105,9 +105,19 @@ class Tests(unittest.TestCase):
 
     def test_LibraryOfAssemblage(self):
         for i in range(50):
-            seed = self.createSeed(f"test_RegularJSmartee{i}",[],[],[],[], reportDepth=None, library=True)
+            seed = self.createSeed(f"test_LibraryOfAssemblage{i}",[],[],[],[], reportDepth=None, library=True)
             hints = self.getHints(seed)
             self.sanityReportChecks(seed,hints)
+
+    def test_howManySelfHintedReportSeeds(self):
+        self_hinted_count = 0
+        for i in range(50):
+            seed = self.createSeed(f"test_howManySelfHintedReportSeeds{i}",[],[],[],[], reportDepth=None)
+            hints = self.getHints(seed,preventSelfHinted=False)
+            if self.areThereSelfHintedReports(hints):
+                self_hinted_count+=1
+        print(self_hinted_count)
+
 
 
     @staticmethod
@@ -177,6 +187,15 @@ class Tests(unittest.TestCase):
         for i in range(13):
             assert hinted_worlds[i] != hint_locations[i], f"A report was self hinted {hinted_worlds[i]} {hint_locations[i]}"
 
+    @staticmethod
+    def areThereSelfHintedReports(hints):
+        hinted_worlds = Tests.getHintedWorlds(hints)
+        hint_locations = Tests.getHintLocations(hints)
+        selfHinted = False
+        for i in range(13):
+            selfHinted |= hinted_worlds[i] == hint_locations[i]
+        return selfHinted
+
 
     @staticmethod
     def auxHintTests(randomizer,hints):
@@ -226,8 +245,8 @@ class Tests(unittest.TestCase):
     def getReportDepths(randomizer):
         return [location.LocationDepth for location,item in randomizer._locationItems if item.ItemType==itemType.REPORT]
     @staticmethod
-    def getHints(randomizer):
-        hints = Hints.generateHints(randomizer._locationItems, "JSmartee", randomizer.seedName, [])
+    def getHints(randomizer, preventSelfHinted=True):
+        hints = Hints.generateHints(randomizer._locationItems, "JSmartee", randomizer.seedName, [], preventSelfHinted)
         if type(hints) is not dict:
             return None
         return hints


### PR DESCRIPTION
Adding an option for report hints to not prevent self-hinting reports. CVS settings set the preset to off.