### PR TITLE
Enable spoiler log by default

### DIFF
--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -24,7 +24,7 @@
                 <option disabled selected>Select a Preset</option>
             </select>
         </div>
-        <div><label class="switch"><input type="checkbox" name="spoilerLog" id="spoilerLog"><span class="slider round"></label><label for="spoilerLog">Generate Spoiler Log</label></div>
+        <div><label class="switch"><input type="checkbox" name="spoilerLog" id="spoilerLog" checked><span class="slider round"></label><label for="spoilerLog">Generate Spoiler Log</label></div>
     </div>
     <div class="container">
         <h4>Item Randomizer</h4>


### PR DESCRIPTION
Proposing this change under the assumption that the vast majority of generated seeds are either for individual use or casual races.

Custom presets probably renders this moot eventually, assuming that the preset will include the spoiler log option as part of the preset, though I still like the thought of just always making spoiler log available to whoever generated the seed as a separate download they can choose to share or not (#57).