### PR TITLE
Encode the app version in the share string

### DIFF
--- a/Class/seedSettings.py
+++ b/Class/seedSettings.py
@@ -8,9 +8,6 @@ from List.configDict import locationType, locationDepth
 from Module.randomBGM import RandomBGM
 from Module.randomCmdMenu import RandomCmdMenu
 
-# Token stored with the settings string to determine if a settings string is compatible with this application version
-SETTINGS_STRING_VERSION = 2
-
 # Characters safe to use in settings strings
 _available_chars = string.digits + string.ascii_uppercase + string.ascii_lowercase
 
@@ -630,6 +627,8 @@ for boss_enemy_setting in boss_enemy_settings:
 settings_by_name = {setting.name: setting for setting in _all_settings}
 
 DELIMITER = "-"
+
+
 class SeedSettings:
 
     def __init__(self):
@@ -645,7 +644,7 @@ class SeedSettings:
         return {name: setting for (name, setting) in settings_by_name.items() if setting.shared or include_private}
 
     def settings_string(self, include_private: bool = False):
-        values = [str(SETTINGS_STRING_VERSION)]
+        values = []
         for name in sorted(self._filtered_settings(include_private)):
             setting = settings_by_name[name]
             values.append(setting.settings_string(self.values[name]))
@@ -653,10 +652,6 @@ class SeedSettings:
 
     def apply_settings_string(self, settings_string: str, include_private: bool = False):
         parts = settings_string.split(DELIMITER)
-        version = int(parts.pop(0))
-        if version != SETTINGS_STRING_VERSION:
-            print('Versions do not match - cannot import settings string')
-            return
         for index, name in enumerate(sorted(self._filtered_settings(include_private))):
             setting = settings_by_name[name]
             self.values[name] = setting.parse_settings_string(parts[index])

--- a/Module/seedshare.py
+++ b/Module/seedshare.py
@@ -1,0 +1,68 @@
+import textwrap
+
+
+SEED_SPLITTER = '$'
+
+
+class SharedSeed:
+
+    def __init__(self, generator_version: str, seed_name: str, spoiler_log: bool, settings_string: str):
+        self.generator_version = generator_version
+        self.seed_name = seed_name
+        self.spoiler_log = spoiler_log
+        self.settings_string = settings_string
+
+    def to_share_string(self) -> str:
+        return SEED_SPLITTER.join([
+            self.generator_version,
+            self.seed_name,
+            '1' if self.spoiler_log else '0',
+            self.settings_string
+        ])
+
+    @classmethod
+    def from_share_string(cls, local_generator_version: str, share_string: str):
+        parts = share_string.split(SEED_SPLITTER)
+
+        if len(parts) != 4:
+            raise InvalidShareStringFormatException(textwrap.dedent(
+                '''
+                Unrecognized seed format.
+                Make sure you are on the same seed generator version as the person who shared the seed with you.
+                '''
+            ))
+
+        seed_generator_version = parts[0]
+        if seed_generator_version != local_generator_version:
+            raise IncompatibleShareStringVersionException(textwrap.dedent(
+                '''
+                Incompatible seed versions.
+                Seed was generated from {0} and your version is {1}.
+                Make sure you are on the same seed generator version as the person who shared the seed with you.
+                '''.format(seed_generator_version, local_generator_version)
+            ))
+
+        return SharedSeed(
+            generator_version=seed_generator_version,
+            seed_name=parts[1],
+            spoiler_log=True if parts[2] == '1' else False,
+            settings_string=parts[3]
+        )
+
+
+class ShareStringException(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+
+class InvalidShareStringFormatException(ShareStringException):
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class IncompatibleShareStringVersionException(ShareStringException):
+
+    def __init__(self, message):
+        super().__init__(message)


### PR DESCRIPTION
The seed share string now includes the app version at the front, and the app alerts the user if an unrecognized string or a string from a different version is imported.

Made a quick change to include the app version in the title too (I know it's in About but might be easier when troubleshooting to have someone be able to find it even quicker).