### PR TITLE
Move resource path function to a single location

### DIFF
--- a/Module/resources.py
+++ b/Module/resources.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+
+def resource_path(relative_path: str) -> str:
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__))[:-6])
+    return os.path.join(base_path, relative_path)

--- a/UI/Submenus/SubMenu.py
+++ b/UI/Submenus/SubMenu.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Optional
 
 from PySide6.QtCore import Qt, QSize
@@ -11,12 +10,7 @@ from PySide6.QtWidgets import (
 
 import Class.seedSettings
 from Class.seedSettings import SeedSettings, Toggle, IntSpinner, FloatSpinner, SingleSelect, MultiSelect
-
-
-def resource_path(relative_path):
-    """ Get absolute path to resource, works for dev and for PyInstaller """
-    base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_path, relative_path)
+from Module.resources import resource_path
 
 
 class KH2Submenu(QWidget):

--- a/localUI.py
+++ b/localUI.py
@@ -2,14 +2,10 @@ import os
 import sys
 
 
-# Keep resource_path definition and the setting of the environment variable as close to the top as possible.
-# These need to happen before anything Boss/Enemy Rando gets loaded for the sake of the distributed binary.
-def resource_path(relative_path):
-    """ Get absolute path to resource, works for dev and for PyInstaller """
-    base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_path, relative_path)
+from Module.resources import resource_path
 
-
+# Keep the setting of the environment variable as close to the top as possible.
+# This needs to happen before anything Boss/Enemy Rando gets loaded for the sake of the distributed binary.
 os.environ["USE_KH2_GITPATH"] = resource_path("extracted_data")
 
 


### PR DESCRIPTION
This hopefully resolves the TODO in `zipper.py` as well as consolidates and simplifies usage of `resource_path` across the board, rather than defining `resource_path` separately in several files.

Tested in both dev build and in building the normal and debug EXEs. Couldn't test `jiminy.bar` for puzzles since there seems to be possibly something broken with turning on puzzle pieces on 2.0 branch even before these changes.