### PR TITLE
Clean up some UI

### DIFF
--- a/Class/seedSettings.py
+++ b/Class/seedSettings.py
@@ -584,7 +584,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_PROOF,
-        ui_label="Proof Point Value",
+        ui_label="Proof",
         minimum=0,
         maximum=1000,
         step=1,
@@ -595,7 +595,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_FORM,
-        ui_label="Forms Point Value",
+        ui_label="Drive Form",
         minimum=0,
         maximum=1000,
         step=1,
@@ -606,7 +606,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_MAGIC,
-        ui_label="Magic Point Value",
+        ui_label="Magic",
         minimum=0,
         maximum=1000,
         step=1,
@@ -617,7 +617,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_SUMMON,
-        ui_label="Summon Point Value",
+        ui_label="Summon",
         minimum=0,
         maximum=1000,
         step=1,
@@ -628,7 +628,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_ABILITY,
-        ui_label="SC & OM Point Value",
+        ui_label="Second Chance/Once More",
         minimum=0,
         maximum=1000,
         step=1,
@@ -639,7 +639,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_PAGE,
-        ui_label="Page Point Value",
+        ui_label="Torn Page",
         minimum=0,
         maximum=1000,
         step=1,
@@ -650,7 +650,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_VISIT,
-        ui_label="Visit Unlock Point Value",
+        ui_label="World Key Item",
         minimum=0,
         maximum=1000,
         step=1,
@@ -661,7 +661,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
     IntSpinner(
         name=settingkey.POINTS_REPORT,
-        ui_label="Report Point Value",
+        ui_label="Ansem Report",
         minimum=0,
         maximum=1000,
         step=1,
@@ -672,7 +672,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
     IntSpinner(
         name=settingkey.POINTS_AUX,
-        ui_label="Aux Unlocks Point Value",
+        ui_label="Aux. Unlock",
         minimum=0,
         maximum=1000,
         step=1,
@@ -683,7 +683,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_BONUS,
-        ui_label="Bonus Level Points",
+        ui_label="Bonus Level",
         minimum=-10,
         maximum=1000,
         step=1,
@@ -694,7 +694,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_COMPLETE,
-        ui_label="World Completion Points",
+        ui_label="World Completion",
         minimum=-10,
         maximum=1000,
         step=1,
@@ -705,7 +705,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_FORMLV,
-        ui_label="Form level Points",
+        ui_label="Form Level",
         minimum=-10,
         maximum=1000,
         step=1,
@@ -716,7 +716,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_DEATH,
-        ui_label="Death Penalty Points",
+        ui_label="Death Penalty",
         minimum=-1000,
         maximum=1000,
         step=1,
@@ -727,7 +727,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     IntSpinner(
         name=settingkey.POINTS_BOSS_NORMAL,
-        ui_label="Normal Boss Defeated Points",
+        ui_label="Normal Boss Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -738,7 +738,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_BOSS_AS,
-        ui_label="Absent Silhouette Defeated Points",
+        ui_label="Absent Silhouette Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -749,7 +749,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_BOSS_DATA,
-        ui_label="Data Boss Defeated Points",
+        ui_label="Data Boss Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -760,7 +760,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_BOSS_SEPHIROTH,
-        ui_label="Sephiroth Defeated Points",
+        ui_label="Sephiroth Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -771,7 +771,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_BOSS_TERRA,
-        ui_label="Lingering Will Defeated Points",
+        ui_label="Lingering Will Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -782,7 +782,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     
         IntSpinner(
         name=settingkey.POINTS_BOSS_FINAL,
-        ui_label="Final Xemnas Defeated Points",
+        ui_label="Final Xemnas Defeated",
         minimum=0,
         maximum=1000,
         step=1,
@@ -974,7 +974,7 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
 
     MultiSelect(
         name=settingkey.HINTABLE_CHECKS,
-        ui_label='Hintable Checks',
+        ui_label='Hintable Items',
         choices={
             'magic': 'Magic',
             'form': 'Drive Forms',
@@ -1302,14 +1302,14 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
         ui_label='Remove Wardrobe Wakeup Animation',
         shared=True,
         default=False,
-        tooltip='Wardrobe in BC will not wake up when pushing it.'
+        tooltip='The wardrobe in Beast\'s Castle will not wake up when pushing it.'
     ),
     Toggle(
         name=settingkey.FAST_URNS,
-        ui_label='Fast OC Urns',
+        ui_label='Fast Olympus Coliseum Urns',
         shared=True,
         default=False,
-        tooltip="OC Urns drop a lot more orbs.",
+        tooltip="The urns in the minigame in Olympus Coliseum drop more orbs, making the minigame much faster.",
         randomizable=False
     ),
     Toggle(
@@ -1368,10 +1368,10 @@ popup locations and lets them appear in chests. Those bonus locations can now ha
     ),
     Toggle(
         name=settingkey.SHOP_UNLOCKS,
-        ui_label='Add World Unlock Items To Shop',
+        ui_label='Add World Key Items To Shop',
         shared=True,
         default=False,
-        tooltip="Adds duplicates of world unlock items into the moogle shop.",
+        tooltip="Adds duplicates of world key items into the moogle shop.",
         randomizable=False
     ),
 

--- a/UI/Submenus/BattleLevelMenu.py
+++ b/UI/Submenus/BattleLevelMenu.py
@@ -8,7 +8,7 @@ from Module.battleLevels import BtlvViewer
 
 class BattleLevelMenu(KH2Submenu):
     def __init__(self, settings: SeedSettings):
-        super().__init__(title='World Battle Levels', settings=settings, in_layout='horizontal')
+        super().__init__(title='Battle Levels', settings=settings, in_layout='horizontal')
         self.world_level_labels = {}
         self.battle_levels = BtlvViewer()
 

--- a/UI/Submenus/HintsMenu.py
+++ b/UI/Submenus/HintsMenu.py
@@ -22,6 +22,7 @@ class HintsMenu(KH2Submenu):
         self.end_column(stretch_at_end=False)
 
         self.start_column()
+        self.addHeader('Item Point Values')
         self.add_option(settingkey.POINTS_REPORT)
         self.add_option(settingkey.POINTS_PROOF)
         self.add_option(settingkey.POINTS_FORM)
@@ -34,6 +35,7 @@ class HintsMenu(KH2Submenu):
         self.end_column()
 
         self.start_column()
+        self.addHeader('Other Point Values')
         self.add_option(settingkey.POINTS_BONUS)
         self.add_option(settingkey.POINTS_COMPLETE)
         self.add_option(settingkey.POINTS_FORMLV)

--- a/UI/Submenus/ItemPlacementMenu.py
+++ b/UI/Submenus/ItemPlacementMenu.py
@@ -9,35 +9,8 @@ from UI.Submenus.SubMenu import KH2Submenu
 class ItemPlacementMenu(KH2Submenu):
 
     def __init__(self, settings: SeedSettings):
-        super().__init__(title='Item Pool and Placement', settings=settings, in_layout='horizontal')
+        super().__init__(title='Item Placement', settings=settings, in_layout='horizontal')
         self.disable_signal = False
-
-        self.start_column()
-        self.addHeader('Include in Item Pool')
-        self.add_option(settingkey.STATSANITY)
-        self.add_option(settingkey.FIFTY_AP_BOOSTS)
-        self.add_option(settingkey.ENABLE_PROMISE_CHARM)
-        self.add_option(settingkey.PUREBLOOD)
-        self.add_option(settingkey.ANTIFORM)
-        self.add_option(settingkey.MAPS_IN_ITEM_POOL)
-        self.add_option(settingkey.RECIPES_IN_ITEM_POOL)
-        self.add_option(settingkey.ACCESSORIES_IN_ITEM_POOL)
-        self.add_option(settingkey.ARMOR_IN_ITEM_POOL)
-        self.add_option(settingkey.ABILITY_POOL)
-        self.end_column()
-
-        self.start_column()
-        self.add_option(settingkey.JUNK_ITEMS)
-
-        junk_widget_layout = QHBoxLayout()
-        junk_widget = QWidget()
-        junk_widget.setLayout(junk_widget_layout)
-        select_all_junk = QPushButton("Select All")
-        select_better_junk = QPushButton("No Synth")
-        junk_widget_layout.addWidget(select_all_junk)
-        junk_widget_layout.addWidget(select_better_junk)
-        self._add_option_widget("", "", junk_widget)
-        self.end_column(stretch_at_end=False)
 
         self.start_column()
         self.addHeader("Where Items Can Go")
@@ -47,12 +20,15 @@ class ItemPlacementMenu(KH2Submenu):
         self.add_option(settingkey.NIGHTMARE_LOGIC)
         self.add_option(settingkey.STORY_UNLOCK_CATEGORY)
         self.add_option(settingkey.STORY_UNLOCK_DEPTH)
-        self.addHeader("")
+        self.end_column()
+
+        self.start_column()
         self.addHeader("Proof Restrictions")
         self.add_option(settingkey.YEET_THE_BEAR)
         self.add_option(settingkey.PROOF_DEPTH)
-        self.addHeader("")
-        self.addHeader("")
+        self.end_column()
+
+        self.start_column()
         self.addHeader("Chain Logic")
         self.add_option(settingkey.CHAIN_LOGIC)
         self.add_option(settingkey.CHAIN_LOGIC_LENGTH)
@@ -62,25 +38,8 @@ class ItemPlacementMenu(KH2Submenu):
 
         self.finalizeMenu()
 
-        select_all_junk.clicked.connect(lambda: self.toggle_all_items())
-        select_better_junk.clicked.connect(lambda: self.toggle_better_junk())
         settings.observe(settingkey.ITEM_PLACEMENT_DIFFICULTY, self.nightmare_checking)
         settings.observe(settingkey.ITEM_PLACEMENT_DIFFICULTY, self.key_item_weights)
-
-    def toggle_all_items(self):
-        setting, widget = self.widgets_and_settings_by_name[settingkey.JUNK_ITEMS]
-        for selected in setting.choice_keys:
-            index = setting.choice_keys.index(selected)
-            widget.item(index).setSelected(True)
-
-    def toggle_better_junk(self):
-        betterJunk = [
-            int(elem.Id) for elem in Items.getJunkList(True)
-        ]
-        setting, widget = self.widgets_and_settings_by_name[settingkey.JUNK_ITEMS]
-        for selected in setting.choice_keys:
-            index = setting.choice_keys.index(selected)
-            widget.item(index).setSelected(int(selected) in betterJunk)
 
     def nightmare_checking(self):
         placement_difficulty = self.settings.get(settingkey.ITEM_PLACEMENT_DIFFICULTY)

--- a/UI/Submenus/ItemPoolMenu.py
+++ b/UI/Submenus/ItemPoolMenu.py
@@ -1,0 +1,63 @@
+from PySide6.QtWidgets import QHBoxLayout, QWidget, QPushButton
+
+from Class import settingkey
+from Class.seedSettings import SeedSettings
+from List.ItemList import Items
+from UI.Submenus.SubMenu import KH2Submenu
+
+
+class ItemPoolMenu(KH2Submenu):
+
+    def __init__(self, settings: SeedSettings):
+        super().__init__(title='Item Pool', settings=settings, in_layout='horizontal')
+        self.disable_signal = False
+
+        self.start_column()
+        self.addHeader('Include in Item Pool')
+        self.add_option(settingkey.STATSANITY)
+        self.add_option(settingkey.FIFTY_AP_BOOSTS)
+        self.add_option(settingkey.ENABLE_PROMISE_CHARM)
+        self.add_option(settingkey.PUREBLOOD)
+        self.add_option(settingkey.ANTIFORM)
+        self.add_option(settingkey.MAPS_IN_ITEM_POOL)
+        self.add_option(settingkey.RECIPES_IN_ITEM_POOL)
+        self.add_option(settingkey.ACCESSORIES_IN_ITEM_POOL)
+        self.add_option(settingkey.ARMOR_IN_ITEM_POOL)
+        self.add_option(settingkey.ABILITY_POOL)
+        self.end_column()
+
+        self.start_column()
+        self.add_option(settingkey.JUNK_ITEMS)
+
+        junk_widget_layout = QHBoxLayout()
+        junk_widget = QWidget()
+        junk_widget.setLayout(junk_widget_layout)
+        select_all_junk = QPushButton("Select All")
+        select_better_junk = QPushButton("No Synth")
+        junk_widget_layout.addWidget(select_all_junk)
+        junk_widget_layout.addWidget(select_better_junk)
+        self._add_option_widget("", "", junk_widget)
+        self.end_column(stretch_at_end=False)
+        select_all_junk.clicked.connect(lambda: self.toggle_all_items())
+        select_better_junk.clicked.connect(lambda: self.toggle_better_junk())
+
+        self.finalizeMenu()
+
+    def toggle_all_items(self):
+        setting, widget = self.widgets_and_settings_by_name[settingkey.JUNK_ITEMS]
+        for selected in setting.choice_keys:
+            index = setting.choice_keys.index(selected)
+            widget.item(index).setSelected(True)
+
+    def toggle_better_junk(self):
+        betterJunk = [
+            int(elem.Id) for elem in Items.getJunkList(True)
+        ]
+        setting, widget = self.widgets_and_settings_by_name[settingkey.JUNK_ITEMS]
+        for selected in setting.choice_keys:
+            index = setting.choice_keys.index(selected)
+            widget.item(index).setSelected(int(selected) in betterJunk)
+
+    def disable_widgets(self):
+        self.disable_signal = True
+        super().disable_widgets()

--- a/UI/Submenus/SeedModMenu.py
+++ b/UI/Submenus/SeedModMenu.py
@@ -15,8 +15,9 @@ class SeedModMenu(KH2Submenu):
         self.add_option(settingkey.TT1_JAILBREAK)
         self.add_option(settingkey.SKIP_CARPET_ESCAPE)
         self.add_option(settingkey.PR_MAP_SKIP)
-        self.add_option(settingkey.ATLANTICA_TUTORIAL_SKIP)
         self.add_option(settingkey.REMOVE_WARDROBE_ANIMATION)
+        self.add_option(settingkey.FAST_URNS)
+        self.add_option(settingkey.ATLANTICA_TUTORIAL_SKIP)
         self.end_column()
 
         self.start_column()

--- a/UI/Submenus/ShopDrop.py
+++ b/UI/Submenus/ShopDrop.py
@@ -6,7 +6,7 @@ from UI.Submenus.SubMenu import KH2Submenu
 class ShopDropMenu(KH2Submenu):
 
     def __init__(self, settings: SeedSettings):
-        super().__init__(title='Shops and Drops', settings=settings, in_layout='horizontal')
+        super().__init__(title='Shops/Drops', settings=settings, in_layout='horizontal')
 
         self.start_column()
         self.addHeader('Shops')
@@ -21,7 +21,6 @@ class ShopDropMenu(KH2Submenu):
         self.add_option(settingkey.GLOBAL_LUCKY)
         self.add_option(settingkey.RICH_ENEMIES)
         self.add_option(settingkey.UNLIMITED_MP)
-        self.add_option(settingkey.FAST_URNS)
         self.end_column(stretch_at_end=True)
         
         self.finalizeMenu()

--- a/UI/Submenus/SoraMenu.py
+++ b/UI/Submenus/SoraMenu.py
@@ -6,7 +6,7 @@ from UI.Submenus.SubMenu import KH2Submenu
 class SoraMenu(KH2Submenu):
 
     def __init__(self, settings: SeedSettings):
-        super().__init__(title='Experience and Stats', settings=settings, in_layout='horizontal')
+        super().__init__(title='EXP/Stats', settings=settings, in_layout='horizontal')
 
         self.start_column()
         self.add_option(settingkey.GLASS_CANNON)

--- a/UI/Submenus/StartingMenu.py
+++ b/UI/Submenus/StartingMenu.py
@@ -8,13 +8,16 @@ from UI.Submenus.SubMenu import KH2Submenu
 class StartingMenu(KH2Submenu):
 
     def __init__(self, settings: SeedSettings):
-        super().__init__(title='Starting Items', settings=settings, in_layout='horizontal')
+        super().__init__(title='Starting Inventory', settings=settings, in_layout='horizontal')
 
         self.start_column()
         self.addHeader("Starting Inventory Options")
         self.add_option(settingkey.AUTO_EQUIP_START_ABILITIES)
         self.add_option(settingkey.STARTING_MOVEMENT)
         self.add_option(settingkey.STARTING_REPORTS)
+        self.end_column()
+
+        self.start_column()
         self.add_option(settingkey.STARTING_INVENTORY)
         self.end_column(stretch_at_end=False)
         self.start_column()

--- a/UI/Submenus/SubMenu.py
+++ b/UI/Submenus/SubMenu.py
@@ -1,12 +1,11 @@
 import os
-from secrets import choice
 from typing import Optional
 
 from PySide6.QtCore import Qt, QSize
-from PySide6.QtGui import QIcon,QPixmap
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QCheckBox, QComboBox, QDoubleSpinBox, QFrame, QGridLayout, QGroupBox, QHBoxLayout, QLabel, QListWidget,
-    QPushButton, QSpinBox, QWidget, QVBoxLayout, QAbstractItemView,QRadioButton,QSizePolicy
+    QPushButton, QSpinBox, QWidget, QVBoxLayout, QAbstractItemView, QRadioButton
 )
 
 import Class.seedSettings
@@ -138,16 +137,10 @@ class KH2Submenu(QWidget):
         widgets = []
         selected_keys = self.settings.get(setting_name)
         partial_keys = []
-        if isinstance(selected_keys[0],list):
+        if isinstance(selected_keys[0], list):
             partial_keys = selected_keys[1]
             selected_keys = selected_keys[0]
         for index, choice_key in enumerate(setting.choice_keys):
-            groupbox = QGroupBox(setting.choice_values[index])
-            groupbox.setAlignment(Qt.AlignCenter)
-            groupbox.setSizePolicy(QSizePolicy(QSizePolicy.Minimum,QSizePolicy.Minimum))
-            groupbox.setMaximumHeight(70)
-            groupbox.setMinimumWidth(250)
-
             randomize_button = QRadioButton("Rando")
             vanilla_button = QRadioButton("Vanilla")
             junk_button = QRadioButton("Junk")
@@ -162,23 +155,36 @@ class KH2Submenu(QWidget):
             vanilla_button.toggled.connect(lambda state: self._update_multi_tristate_buttons(setting))
             junk_button.toggled.connect(lambda state: self._update_multi_tristate_buttons(setting))
 
-            self.tristate_groups[choice_key] = (randomize_button,vanilla_button,junk_button)
+            self.tristate_groups[choice_key] = (randomize_button, vanilla_button, junk_button)
 
-            layout = QHBoxLayout()
-            layout.setContentsMargins(0,0,0,0)
+            top_layout = QHBoxLayout()
+            world_label = QLabel(setting.choice_values[index])
+            world_label.setProperty('cssClass', 'small')
+            top_layout.addWidget(world_label)
+
+            bottom_layout = QHBoxLayout()
+            bottom_layout.setContentsMargins(4, 0, 4, 0)
             label = QLabel()
             icon = QIcon(resource_path(dir_path + '/' + setting.choice_icons[choice_key]))
-            pixmap = icon.pixmap(icon.actualSize(QSize(36, 36)))
+            pixmap = icon.pixmap(icon.actualSize(QSize(32, 32)))
             label.setPixmap(pixmap)
-            layout.addWidget(label)
-            layout.addWidget(randomize_button)
-            layout.addWidget(vanilla_button)
-            layout.addWidget(junk_button)
-            layout.insertStretch(-1,1)
+            bottom_layout.addWidget(label)
+            button_layout = QHBoxLayout()
+            button_layout.addWidget(randomize_button)
+            button_layout.addWidget(vanilla_button)
+            button_layout.addWidget(junk_button)
+            bottom_layout.addLayout(button_layout)
 
-            groupbox.setLayout(layout)
-            self.tristate_backgrounds[choice_key] = groupbox
-            widgets.append(groupbox)
+            vertical = QVBoxLayout()
+            vertical.setContentsMargins(4, 4, 4, 4)
+            vertical.addLayout(top_layout)
+            vertical.addLayout(bottom_layout)
+            self.tristate_backgrounds[choice_key] = world_label
+
+            widget = QWidget()
+            widget.setStyleSheet('background-color: #232629')
+            widget.setLayout(vertical)
+            widgets.append(widget)
 
         self.widgets_and_settings_by_name[setting_name] = (setting, widgets)
         self._update_multi_tristate_buttons(setting)
@@ -212,14 +218,13 @@ class KH2Submenu(QWidget):
 
         return setting, widgets
 
-    def add_multiselect_buttons(self, setting_name: str, columns: int, group_title: str, tristate = False):
-
+    def add_multiselect_buttons(self, setting_name: str, columns: int, group_title: str, tristate=False):
         grid = QGridLayout()
         grid.setAlignment(Qt.AlignTop)
         if tristate:
             setting, widgets = self.make_multiselect_tristate(setting_name)
-            grid.setContentsMargins(0,0,0,0)
-            grid.setSpacing(3)
+            grid.setContentsMargins(0, 0, 0, 0)
+            grid.setSpacing(4)
         else:
             setting, widgets = self.make_multiselect_buttons(setting_name)
 
@@ -423,14 +428,14 @@ class KH2Submenu(QWidget):
         selected_keys = []
         partial_keys = []
         for index, button in enumerate(buttons):
-            rando,vanil,junk = self.tristate_groups[choice_keys[index]]
+            rando, vanil, junk = self.tristate_groups[choice_keys[index]]
             choice_group = self.tristate_backgrounds[choice_keys[index]]
             if rando.isChecked():
                 selected_keys.append(choice_keys[index])
-                choice_group.setStyleSheet("QGroupBox::title {background-color: #2E7D32}")
+                choice_group.setStyleSheet("QLabel {background-color: #2E7D32}")
             elif vanil.isChecked():
-                choice_group.setStyleSheet("QGroupBox::title {background-color: gray}")
+                choice_group.setStyleSheet("QLabel {background-color: gray}")
                 partial_keys.append(choice_keys[index])
             else:
-                choice_group.setStyleSheet("QGroupBox::title {background-color: {QTMATERIAL_PRIMARYCOLOR}}")
-        self.settings.set(setting.name, [selected_keys,partial_keys])
+                choice_group.setStyleSheet("QLabel {background-color: {QTMATERIAL_PRIMARYCOLOR}}")
+        self.settings.set(setting.name, [selected_keys, partial_keys])

--- a/UI/stylesheet.css
+++ b/UI/stylesheet.css
@@ -26,6 +26,10 @@ QLabel[cssClass~="header"] {{
     font-size: 20px;
 }}
 
+QLabel[cssClass~="small"] {{
+    font-size: 14px;
+}}
+
 QListView::item:selected {{
   background-color: {QTMATERIAL_PRIMARYCOLOR};
   selection-background-color: {QTMATERIAL_PRIMARYCOLOR};

--- a/localUI.py
+++ b/localUI.py
@@ -45,6 +45,7 @@ from UI.Submenus.BossEnemyMenu import BossEnemyMenu
 from UI.Submenus.CosmeticsMenu import CosmeticsMenu
 from UI.Submenus.HintsMenu import HintsMenu
 from UI.Submenus.ItemPlacementMenu import ItemPlacementMenu
+from UI.Submenus.ItemPoolMenu import ItemPoolMenu
 from UI.Submenus.KeybladeMenu import KeybladeMenu
 from UI.Submenus.RewardLocationsMenu import RewardLocationsMenu
 from UI.Submenus.SeedModMenu import SeedModMenu
@@ -240,6 +241,7 @@ class KH2RandomizerApp(QMainWindow):
             StartingMenu(self.settings),
             HintsMenu(self.settings),
             KeybladeMenu(self.settings),
+            ItemPoolMenu(self.settings),
             ItemPlacementMenu(self.settings),
             SeedModMenu(self.settings),
             BattleLevelMenu(self.settings),


### PR DESCRIPTION
- fix some sizing on the locations page
- shorten some tab titles to avoid scrolling
- separate item pool from item placement for more room to grow
- reduce some mostly-redundant wording for labels on Hints page
- move fast urns to QoL, feels like it fits better there
- use consistent naming for "world key items"