### PR TITLE
Allow resizing the app window and add scrollbars as needed

### DIFF
--- a/Module/appconfig.py
+++ b/Module/appconfig.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+
+def read_app_config() -> dict:
+    config_path = Path('randomizer-config.json').absolute()
+    if config_path.is_file():
+        with open(config_path, encoding='utf-8') as config_file:
+            return json.load(config_file)
+    else:
+        return {}
+
+
+def write_app_config(config: dict):
+    config_path = Path('randomizer-config.json').absolute()
+    with open(config_path, mode='w', encoding='utf-8') as config_file:
+        json.dump(config, config_file, indent=4)
+
+
+def update_app_config(key: str, value):
+    randomizer_config = read_app_config()
+    randomizer_config[key] = value
+    write_app_config(randomizer_config)
+
+
+def remove_app_config(key: str):
+    randomizer_config = read_app_config()
+    if key in randomizer_config:
+        del randomizer_config[key]
+        write_app_config(randomizer_config)

--- a/Module/cosmetics.py
+++ b/Module/cosmetics.py
@@ -8,6 +8,7 @@ import yaml
 
 from Class import settingkey
 from Class.seedSettings import SeedSettings
+from Module import appconfig
 from Module.RandomizerSettings import RandomizerSettings
 from Module.music import default_music_list
 
@@ -190,7 +191,7 @@ class CosmeticsMod:
 
     @staticmethod
     def read_openkh_path() -> Optional[Path]:
-        randomizer_config = CosmeticsMod._read_randomizer_config()
+        randomizer_config = appconfig.read_app_config()
         openkh_path = Path(randomizer_config.get('openkh_folder', 'to-nowhere'))
         if openkh_path.is_dir():
             return openkh_path
@@ -199,13 +200,11 @@ class CosmeticsMod:
 
     @staticmethod
     def write_openkh_path(selected_directory):
-        randomizer_config = CosmeticsMod._read_randomizer_config()
-        randomizer_config['openkh_folder'] = selected_directory
-        CosmeticsMod._write_randomizer_config(randomizer_config)
+        appconfig.update_app_config('openkh_folder', selected_directory)
 
     @staticmethod
     def read_custom_music_path() -> Optional[Path]:
-        randomizer_config = CosmeticsMod._read_randomizer_config()
+        randomizer_config = appconfig.read_app_config()
         custom_music_path = Path(randomizer_config.get('custom_music_folder', 'to-nowhere'))
         if custom_music_path.is_dir():
             return custom_music_path
@@ -214,21 +213,4 @@ class CosmeticsMod:
 
     @staticmethod
     def write_custom_music_path(selected_directory):
-        randomizer_config = CosmeticsMod._read_randomizer_config()
-        randomizer_config['custom_music_folder'] = selected_directory
-        CosmeticsMod._write_randomizer_config(randomizer_config)
-
-    @staticmethod
-    def _read_randomizer_config():
-        config_path = Path('randomizer-config.json').absolute()
-        if config_path.is_file():
-            with open(config_path, encoding='utf-8') as config_file:
-                return json.load(config_file)
-        else:
-            return {}
-
-    @staticmethod
-    def _write_randomizer_config(randomizer_config):
-        config_path = Path('randomizer-config.json').absolute()
-        with open(config_path, mode='w', encoding='utf-8') as config_file:
-            json.dump(randomizer_config, config_file, indent=4)
+        appconfig.update_app_config('custom_music_folder', selected_directory)

--- a/UI/Submenus/SubMenu.py
+++ b/UI/Submenus/SubMenu.py
@@ -1,12 +1,11 @@
 import os
-import random
 from typing import Optional
 
 from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QCheckBox, QComboBox, QDoubleSpinBox, QFrame, QGridLayout, QGroupBox, QHBoxLayout, QLabel, QListWidget,
-    QPushButton, QSpinBox, QWidget, QVBoxLayout, QAbstractItemView, QRadioButton
+    QPushButton, QSpinBox, QWidget, QVBoxLayout, QAbstractItemView, QRadioButton, QScrollArea
 )
 
 import Class.seedSettings
@@ -314,7 +313,18 @@ class KH2Submenu(QWidget):
 
     def finalizeMenu(self):
         self.menulayout.addStretch(1)
-        self.setLayout(self.menulayout)
+
+        scroll_child = QWidget()
+        scroll_child.setLayout(self.menulayout)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidget(scroll_child)
+        scroll_area.setWidgetResizable(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(scroll_area)
+
+        self.setLayout(layout)
 
     def getName(self):
         return self.title

--- a/localUI.py
+++ b/localUI.py
@@ -5,6 +5,7 @@ import textwrap
 
 from Class.exceptions import CantAssignItemException, RandomizerExceptions
 from List.configDict import locationType
+from Module import appconfig
 
 from Module.resources import resource_path
 from Module.tourneySpoiler import TourneySeedSaver
@@ -343,7 +344,6 @@ class KH2RandomizerApp(QMainWindow):
         random.seed(str(datetime.datetime.now()))
         self.setWindowTitle("KH2 Randomizer Seed Generator ({0})".format(LOCAL_UI_VERSION))
         self.setWindowIcon(QIcon(resource_path("Module/icon.png")))
-        self.setMinimumWidth(1200)
         self.setup = None
         pagelayout = QVBoxLayout()
         seed_layout = QHBoxLayout()
@@ -470,6 +470,9 @@ class KH2RandomizerApp(QMainWindow):
         self.config_menu.addAction('LuaBackend Hook Setup (PC Only)', self.show_luabackend_configuration)
         self.config_menu.addAction('Find OpenKH Folder (for randomized cosmetics)', self.openkh_folder_getter)
         self.config_menu.addAction('Choose Custom Music Folder', self.custom_music_folder_getter)
+        self.config_menu.addSeparator()
+        self.remember_window_position_action = self.config_menu.addAction('Remember Window Size/Position')
+        self.remember_window_position_action.setCheckable(True)
         menu_bar.addMenu(self.seedMenu)
         menu_bar.addMenu(self.presetMenu)
 
@@ -493,6 +496,17 @@ class KH2RandomizerApp(QMainWindow):
             presetData.write(json.dumps(settings_json, indent=4, sort_keys=True))
 
         self.custom_cosmetics.write_file()
+
+        if self.remember_window_position_action.isChecked():
+            obj = {
+                'width': self.width(),
+                'height': self.height(),
+                'x': self.x(),
+                'y': self.y()
+            }
+            appconfig.update_app_config('window_position', obj)
+        else:
+            appconfig.remove_app_config('window_position')
 
         e.accept()
 
@@ -1059,8 +1073,31 @@ if __name__=="__main__":
         window.resetSettings()
         pass
     window.show()
-    center = window.screen().geometry().center()
-    window.move(center.x() - window.width() / 2, center.y() - window.height() / 2)
+
+    app_config = appconfig.read_app_config()
+
+    if 'window_position' in app_config:
+        window.remember_window_position_action.setChecked(True)
+        window_position = app_config['window_position']
+        window.resize(window_position['width'], window_position['height'])
+        window.move(window_position['x'], window_position['y'])
+    else:
+        window.remember_window_position_action.setChecked(False)
+        screen_geometry = window.screen().geometry()
+        top_left = screen_geometry.topLeft()
+        bottom_right = screen_geometry.bottomRight()
+        screen_width = bottom_right.x() - top_left.x()
+        screen_height = bottom_right.y() - top_left.y()
+
+        # This is basically the best effort to get the window sized such that there aren't any scrollbars.
+        # It might need to get updated over time if any of the tabs gets any bigger.
+        # As of when this was written, 1400x900 fits everything other than when progression hints is turned on.
+        # If the screen is smaller than that, try to make it big enough without going full width/height.
+        window.resize(min(1400, screen_width - 64), min(900, screen_height - 64))
+
+        center = screen_geometry.center()
+        window.move(center.x() - window.width() / 2, center.y() - window.height() / 2)
+
     #commenting out first time setup for 2.999 version
     # configPath = Path("rando-config.yml")
     # if not configPath.is_file() or not os.environ.get("ALWAYS_SETUP") is None:


### PR DESCRIPTION
- On startup, try to size the window such that the scrollbars don't appear.
- Add a new option in the Configure menu to remember the window size and position.