### PR TITLE
Create a separate file for seed hash icon names

### DIFF
--- a/Module/zipper.py
+++ b/Module/zipper.py
@@ -390,8 +390,10 @@ class SeedZip():
                 a["source"] = [i for j, i in enumerate(a["source"]) if j not in delete_asset_indices]
 
     def generate_seed_hash_image(self, settings: RandomizerSettings, out_zip: zipfile.ZipFile):
-        image_data = hashimage.generate_seed_hash_image(settings.seedHashIcons, use_bitmap=False)
+        hash_icons = settings.seedHashIcons
+        image_data = hashimage.generate_seed_hash_image(hash_icons, use_bitmap=False)
         out_zip.writestr('preview.png', image_data)
+        out_zip.writestr('misc/randoseed-hash-icons.csv', ','.join(hash_icons))
 
     def createBtlvRandoAssets(self, settings, mod, outZip):
         btlv_option_name = settings.battle_level_rando


### PR DESCRIPTION
Removes the need for tracker (or other future external tool) to read the seed hash information from sys.yml.