### PR TITLE
New Object Ids for Chest Visuals Modifier

### DIFF
--- a/List/ChestList.py
+++ b/List/ChestList.py
@@ -556,75 +556,75 @@ def getChestVisualId(location, item):
     #Pride Lands needs different IDs
     if locationType.PL in location:
         #get correct chest id for item type
-        chestTypeId = 834 #default "Junk" chest visual
+        chestTypeId = 4040 #default "Junk" chest visual
         if item in [itemType.GROWTH_ABILITY, itemType.ACTION_ABILITY, itemType.SUPPORT_ABILITY]:
-            chestTypeId = 835
+            chestTypeId = 4041
         elif item == itemType.FORM:
-            chestTypeId = 2132
+            chestTypeId = 4042
         elif item in [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.MAGNET, itemType.REFLECT]:
-            chestTypeId = 2133
+            chestTypeId = 4043
         elif item == itemType.TORN_PAGE:
-            chestTypeId = 2142                                  
+            chestTypeId = 4044                                  
         elif item == itemType.REPORT:
-            chestTypeId = 2143
+            chestTypeId = 4045
         elif item in [itemType.GAUGE, itemType.SLOT, itemType.MUNNY_POUCH]: #[itemType.GAUGE, itemType.SLOT]:
-            chestTypeId = 2235
+            chestTypeId = 4046
         elif item == itemType.SUMMON:
-            chestTypeId = 2236
+            chestTypeId = 4047
         elif item in [itemType.STORYUNLOCK, itemType.MANUFACTORYUNLOCK, itemType.TROPHY, itemType.OCSTONE]: #== itemType.STORYUNLOCK:
-            chestTypeId = 2540
+            chestTypeId = 4048
         elif item in [itemType.KEYBLADE, itemType.SHIELD, itemType.STAFF]:
-            chestTypeId = 1392
+            chestTypeId = 4049
         elif item in [itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.PROOF, itemType.PROMISE_CHARM]:
-            chestTypeId = 1448
+            chestTypeId = 4050
         return chestTypeId
     #twilight town and STT require different IDs too
     elif locationType.TT in location or locationType.STT in location:
         #get correct chest id for item type
-        chestTypeId = 823 #default "Junk" chest visual
+        chestTypeId = 4020 #default "Junk" chest visual
         if item in [itemType.GROWTH_ABILITY, itemType.ACTION_ABILITY, itemType.SUPPORT_ABILITY]:
-            chestTypeId = 824
+            chestTypeId = 4021
         elif item == itemType.FORM:
-            chestTypeId = 825
+            chestTypeId = 4022
         elif item in [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.MAGNET, itemType.REFLECT]:
-            chestTypeId = 826
+            chestTypeId = 4023
         elif item == itemType.TORN_PAGE:
-            chestTypeId = 827                                  
+            chestTypeId = 4024                                  
         elif item == itemType.REPORT:
-            chestTypeId = 828
+            chestTypeId = 4025
         elif item in [itemType.GAUGE, itemType.SLOT, itemType.MUNNY_POUCH]:
-            chestTypeId = 829
+            chestTypeId = 4026
         elif item == itemType.SUMMON:
-            chestTypeId = 830
+            chestTypeId = 4027
         elif item in [itemType.STORYUNLOCK, itemType.MANUFACTORYUNLOCK, itemType.TROPHY, itemType.OCSTONE]:
-            chestTypeId = 831
+            chestTypeId = 4028
         elif item in [itemType.KEYBLADE, itemType.SHIELD, itemType.STAFF]:
-            chestTypeId = 832
+            chestTypeId = 4029
         elif item in [itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.PROOF, itemType.PROMISE_CHARM]:
-            chestTypeId = 833
+            chestTypeId = 4030
         return chestTypeId
     #default IDs
     else:
         #get correct chest id for item type
-        chestTypeId = 320 #default "Junk" chest visual
+        chestTypeId = 4000 #default "Junk" chest visual
         if item in [itemType.GROWTH_ABILITY, itemType.ACTION_ABILITY, itemType.SUPPORT_ABILITY]:
-            chestTypeId = 321
+            chestTypeId = 4001
         elif item == itemType.FORM:
-            chestTypeId = 322
+            chestTypeId = 4002
         elif item in [itemType.FIRE, itemType.BLIZZARD, itemType.THUNDER, itemType.CURE, itemType.MAGNET, itemType.REFLECT]:
-            chestTypeId = 323
+            chestTypeId = 4003
         elif item == itemType.TORN_PAGE:
-            chestTypeId = 324                                  
+            chestTypeId = 4004                                  
         elif item == itemType.REPORT:
-            chestTypeId = 325
+            chestTypeId = 4005
         elif item in [itemType.GAUGE, itemType.SLOT, itemType.MUNNY_POUCH]:
-            chestTypeId = 818
+            chestTypeId = 4006
         elif item == itemType.SUMMON:
-            chestTypeId = 819
+            chestTypeId = 4007
         elif item in [itemType.STORYUNLOCK, itemType.MANUFACTORYUNLOCK, itemType.TROPHY, itemType.OCSTONE]:
-            chestTypeId = 820
+            chestTypeId = 4008
         elif item in [itemType.KEYBLADE, itemType.SHIELD, itemType.STAFF]:
-            chestTypeId = 821
+            chestTypeId = 4009
         elif item in [itemType.PROOF_OF_CONNECTION, itemType.PROOF_OF_PEACE, itemType.PROOF, itemType.PROMISE_CHARM]:
-            chestTypeId = 822
+            chestTypeId = 4010
         return chestTypeId

--- a/static/chests/ChestObjList.script
+++ b/static/chests/ChestObjList.script
@@ -1,6 +1,6 @@
 #SR Chests
-320:
-  ObjectId: 320
+4000:
+  ObjectId: 4000
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -29,8 +29,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-321:
-  ObjectId: 321
+4001:
+  ObjectId: 4001
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -59,8 +59,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-322:
-  ObjectId: 322
+4002:
+  ObjectId: 4002
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -89,8 +89,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-323:
-  ObjectId: 323
+4003:
+  ObjectId: 4003
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -119,8 +119,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-324:
-  ObjectId: 324
+4004:
+  ObjectId: 4004
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -149,8 +149,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-325:
-  ObjectId: 325
+4005:
+  ObjectId: 4005
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -179,8 +179,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-818:
-  ObjectId: 818
+4006:
+  ObjectId: 4006
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -209,8 +209,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-819:
-  ObjectId: 819
+4007:
+  ObjectId: 4007
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -239,8 +239,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-820:
-  ObjectId: 820
+4008:
+  ObjectId: 4008
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -269,8 +269,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-821:
-  ObjectId: 821
+4009:
+  ObjectId: 4009
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -299,8 +299,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-822:
-  ObjectId: 822
+4010:
+  ObjectId: 4010
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -330,8 +330,8 @@
   WallOcclusion: false
   Hift: false
 #TT Chests
-823:
-  ObjectId: 823
+4020:
+  ObjectId: 4020
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -360,8 +360,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-824:
-  ObjectId: 824
+4021:
+  ObjectId: 4021
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -390,8 +390,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-825:
-  ObjectId: 825
+4022:
+  ObjectId: 4022
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -420,8 +420,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-826:
-  ObjectId: 826
+4023:
+  ObjectId: 4023
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -450,8 +450,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-827:
-  ObjectId: 827
+4024:
+  ObjectId: 4024
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -480,8 +480,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-828:
-  ObjectId: 828
+4025:
+  ObjectId: 4025
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -510,8 +510,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-829:
-  ObjectId: 829
+4026:
+  ObjectId: 4026
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -540,8 +540,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-830:
-  ObjectId: 830
+4027:
+  ObjectId: 4027
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -570,8 +570,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-831:
-  ObjectId: 831
+4028:
+  ObjectId: 4028
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -600,8 +600,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-832:
-  ObjectId: 832
+4029:
+  ObjectId: 4029
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -630,8 +630,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-833:
-  ObjectId: 833
+4030:
+  ObjectId: 4030
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -661,8 +661,8 @@
   WallOcclusion: false
   Hift: false
 #LK Chests
-834:
-  ObjectId: 834
+4040:
+  ObjectId: 4040
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -691,8 +691,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-835:
-  ObjectId: 835
+4041:
+  ObjectId: 4041
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -721,8 +721,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2132:
-  ObjectId: 2132
+4042:
+  ObjectId: 4042
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -751,8 +751,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2133:
-  ObjectId: 2133
+4043:
+  ObjectId: 4043
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -781,8 +781,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2142:
-  ObjectId: 2142
+4044:
+  ObjectId: 4044
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -811,8 +811,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2143:
-  ObjectId: 2143
+4045:
+  ObjectId: 4045
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -841,8 +841,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2235:
-  ObjectId: 2235
+4046:
+  ObjectId: 4046
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -871,8 +871,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2236:
-  ObjectId: 2236
+4047:
+  ObjectId: 4047
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -901,8 +901,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-2540:
-  ObjectId: 2540
+4048:
+  ObjectId: 4048
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -931,8 +931,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-1392:
-  ObjectId: 1392
+4049:
+  ObjectId: 4049
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0
@@ -961,8 +961,8 @@
   IsPirate: false
   WallOcclusion: false
   Hift: false
-1448:
-  ObjectId: 1448
+4050:
+  ObjectId: 4050
   ObjectType: TREASURE
   SubType: 0
   DrawPriority: 0


### PR DESCRIPTION
Changes the chest IDs to use brand new custom ones.
This change requires the new GoA ROM because it will offset the 00objentry.bin.
Benefits to this include no longer requiring to edit the normal chest objects + a Donald staff, and to prevent t-posing that can happen in a rare instance where OpenKH does not patch in the new chest IDs. (this is a bug with OpenKH and not the chest visuals as far as I can tell because the changes will often take affect when repatching the game with no changes to the seed or modlist.)