### PR TITLE
Added "Custom" starting visit mode to combine random and specific visit settings

### DIFF
--- a/Class/seedSettings.py
+++ b/Class/seedSettings.py
@@ -2570,6 +2570,9 @@ _all_settings = [
         Random Visits - Unlock a random set of visits by starting with random visit unlock items.
 
         Specific Visits - Unlock a specific set of visits by starting with specific visit unlock items.
+
+        Custom - Combination of the "Random Visits" and "Specific Visits" modes. Unlock a specific set of
+        visits, and then additionally unlock a random set of visits.
         """,
     ),
     IntSpinner(

--- a/List/configDict.py
+++ b/List/configDict.py
@@ -258,6 +258,7 @@ class StartingVisitMode(str, Enum):
     NONE = "No Visits"
     RANDOM = "Random Visits"
     SPECIFIC = "Specific Visits"
+    CUSTOM = "Custom"
 
 
 class FinalDoorRequirement(str, Enum):

--- a/Module/RandomizerSettings.py
+++ b/Module/RandomizerSettings.py
@@ -817,8 +817,17 @@ class RandomizerSettings:
         elif starting_visit_mode is StartingVisitMode.SPECIFIC:
             for _, count in self.starting_unlocks_per_world.items():
                 starting_visit_items_count = starting_visit_items_count + count
+        elif starting_visit_mode is StartingVisitMode.CUSTOM:
+            for _, count in self.starting_unlocks_per_world.items():
+                starting_visit_items_count = starting_visit_items_count + count
+            starting_visit_items_count = starting_visit_items_count + self.starting_visit_random_range[1]
 
         max_unlocks = len(storyunlock.all_individual_story_unlocks())
+        if starting_visit_items_count > max_unlocks:
+            raise SettingsException(
+                f"Starting Visit Unlocks plus Maximum Visits Available is more than {max_unlocks}"
+            )
+
         if starting_visit_items_count + self.shop_unlocks > max_unlocks:
             raise SettingsException(
                 f"Starting Visit Unlocks plus Visit Unlocks in shop is more than {max_unlocks}"

--- a/Module/modifier.py
+++ b/Module/modifier.py
@@ -231,11 +231,11 @@ class SeedModifier:
             return result
         elif mode is StartingVisitMode.CUSTOM:
             result: list[StoryUnlock] = []
-            for location, count in specific_unlocks.items():
-                result.extend([storyunlock.story_unlock_for_location(location)] * count)
             random_pool: list[StoryUnlock] = []
             for unlock in storyunlock.all_story_unlocks():
-                random_pool.extend([unlock] * (unlock.visit_count - specific_unlocks[unlock.location]))
+                specific_count = specific_unlocks[unlock.location]
+                result.extend([unlock] * specific_count)
+                random_pool.extend([unlock] * (unlock.visit_count - specific_count))
             random_min, random_max = random_range
             random_count = random.randint(random_min, random_max)
             result.extend(random.sample(random_pool, k=random_count))

--- a/Module/modifier.py
+++ b/Module/modifier.py
@@ -229,5 +229,16 @@ class SeedModifier:
             for location, count in specific_unlocks.items():
                 result.extend([storyunlock.story_unlock_for_location(location)] * count)
             return result
+        elif mode is StartingVisitMode.CUSTOM:
+            result: list[StoryUnlock] = []
+            for location, count in specific_unlocks.items():
+                result.extend([storyunlock.story_unlock_for_location(location)] * count)
+            random_pool: list[StoryUnlock] = []
+            for unlock in storyunlock.all_story_unlocks():
+                random_pool.extend([unlock] * (unlock.visit_count - specific_unlocks[unlock.location]))
+            random_min, random_max = random_range
+            random_count = random.randint(random_min, random_max)
+            result.extend(random.sample(random_pool, k=random_count))
+            return result
         else:
             raise GeneratorException(f"Unknown mode {mode}")

--- a/UI/Submenus/RewardLocationsMenu.py
+++ b/UI/Submenus/RewardLocationsMenu.py
@@ -77,11 +77,11 @@ class RewardLocationsMenu(KH2Submenu):
     def _starting_visit_mode_changed(self):
         mode = StartingVisitMode[self.settings.get(settingkey.STARTING_VISIT_MODE)]
 
-        random = mode is StartingVisitMode.RANDOM
+        random = (mode is StartingVisitMode.RANDOM) or (mode is StartingVisitMode.CUSTOM) 
         self.set_option_visibility(settingkey.STARTING_VISIT_RANDOM_MIN, random)
         self.set_option_visibility(settingkey.STARTING_VISIT_RANDOM_MAX, random)
 
-        specific = mode is StartingVisitMode.SPECIFIC
+        specific = (mode is StartingVisitMode.SPECIFIC) or (mode is StartingVisitMode.CUSTOM)
         self.set_option_visibility(settingkey.STARTING_UNLOCKS_STT, specific)
         self.set_option_visibility(settingkey.STARTING_UNLOCKS_HB, specific)
         self.set_option_visibility(settingkey.STARTING_UNLOCKS_OC, specific)


### PR DESCRIPTION
I am using this to make seeds with both random visit unlocks and TWTNW unlocked from the start. Figured others would like this for this purpose, or any other reason.

Open to edits, I can update this when I'm free.