### PR TITLE
Fixes for keyblade cosmetics

### DIFF
--- a/Module/cosmeticsmods/keyblademod.py
+++ b/Module/cosmeticsmods/keyblademod.py
@@ -287,7 +287,7 @@ class KeybladeModParser:
             nonlocal unknown_count
             found_name = keyblade_names.get(found_keyblade.text_id, "")
             if found_name:
-                return found_name
+                return found_name.replace("\n", "")
             else:
                 name = f"Unnamed Keyblade {unknown_count}"
                 unknown_count = unknown_count + 1

--- a/Module/paths.py
+++ b/Module/paths.py
@@ -3,10 +3,19 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 
+def with_caps_extensions(*extensions: str) -> set[str]:
+    """Returns a set containing the given extensions as well as capitalized versions of each."""
+    result = set(extensions)
+    for extension in extensions:
+        result.add(extension.upper())
+    return result
+
+
 def _children_with_extension(path: Path, *extensions: str) -> Iterator[Path]:
     if path.is_dir():
+        all_extensions = with_caps_extensions(*extensions)
         for child in path.iterdir():
-            if child.suffix in extensions:
+            if child.suffix in all_extensions:
                 yield child
 
 
@@ -23,9 +32,10 @@ def child_with_extension(path: Path, *extensions: str) -> Optional[Path]:
 def walk_files_with_extension(path: Path, *extensions: str) -> Iterator[Path]:
     """Returns all children of the given path having one of the given extensions."""
     if path.is_dir():
+        all_extensions = with_caps_extensions(*extensions)
         for root, dirs, files in os.walk(path):
             root_path = Path(root)
             for file in files:
                 file_path = root_path / file
-                if file_path.suffix in extensions:
+                if file_path.suffix in all_extensions:
                     yield file_path

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,14 @@
+import unittest
+
+from Module.paths import with_caps_extensions
+
+
+class Tests(unittest.TestCase):
+
+    def test_with_caps_extensions(self):
+        result = with_caps_extensions(".png", ".dds")
+        self.assertEqual({ ".dds", ".DDS", ".png", ".PNG" }, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Match file extensions in either lower-case or all-caps
- Remove newlines from found keyblade names