### PR TITLE
Create separate thumbnails for keyblade previews

### DIFF
--- a/Module/cosmeticsmods/keyblade.py
+++ b/Module/cosmeticsmods/keyblade.py
@@ -6,6 +6,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Optional, Any
 
+from PIL import Image
+
 from Class.exceptions import GeneratorException
 from Class.openkhmod import AssetPlatform, BinarcMethod, ModAsset, ModBinarcSource, ModSourceFile, StrDict, \
     ObjectEntries
@@ -250,6 +252,12 @@ class ReplacementKeyblade:
 
     def remastered_itempic(self) -> Optional[Path]:
         return child_with_extension(self.keyblade_dir / ITEMPIC, ".dds")
+
+    def itempic_thumbnail(self) -> Optional[Path]:
+        return KeybladeRandomizer.create_thumbnail_if_needed(
+            remastered_itempic=self.remastered_itempic(),
+            target_path=self.keyblade_dir,
+        )
 
     def model(self, variant: KeybladeModelVariant) -> Optional[Path]:
         full_path = self.keyblade_dir / variant.keyblade_mod_subdir_name()
@@ -540,6 +548,20 @@ class KeybladeRandomizer:
                     result.append(ReplacementKeyblade(keyblade_dir.name, keyblade_dir, keyblade_json_file))
 
         return result
+
+    @staticmethod
+    def create_thumbnail_if_needed(remastered_itempic: Optional[Path], target_path: Path) -> Optional[Path]:
+        thumbnail_path = target_path / "thumbnail.png"
+        if thumbnail_path.is_file():
+            return thumbnail_path
+
+        if remastered_itempic and remastered_itempic.is_file():
+            with Image.open(remastered_itempic) as image:
+                resized = image.resize((48, 48))
+                resized.save(thumbnail_path, format="PNG")
+                return thumbnail_path
+        else:
+            return None
 
     @staticmethod
     def collect_vanilla_keyblades() -> list[ReplacementKeyblade]:

--- a/Module/cosmeticsmods/keyblademod.py
+++ b/Module/cosmeticsmods/keyblademod.py
@@ -78,6 +78,11 @@ class ImportableKeyblade:
             if itempic.is_file():
                 shutil.copy2(itempic, out_itempic_path)
 
+        KeybladeRandomizer.create_thumbnail_if_needed(
+            remastered_itempic=self.remastered_itempic,
+            target_path=keyblade_output_location
+        )
+
     def _copy_remastered_files(self, variant: KeybladeModelVariant, variant_path: Path):
         def copy_textures(textures_input: dict[str, Path], textures_output: Path):
             if textures_input:

--- a/UI/Submenus/ManageKeybladesDialog.py
+++ b/UI/Submenus/ManageKeybladesDialog.py
@@ -1,10 +1,9 @@
-import os
 from pathlib import Path
 from typing import Optional
 
 from PIL import Image
 from PySide6.QtCore import QSize
-from PySide6.QtGui import Qt, QPixmap
+from PySide6.QtGui import Qt
 from PySide6.QtWidgets import QDialog, QMenuBar, QMenu, QVBoxLayout, QWidget, QGridLayout, QLabel, QScrollArea, \
     QFileDialog
 
@@ -99,27 +98,15 @@ class ManageKeybladesDialog(QDialog):
         else:
             self._refresh_keyblade_info(vanilla_grid, vanilla_keyblades)
 
-    _itempic_pixmap_cache: dict[tuple[Path, float], QPixmap] = {}
-
-    @staticmethod
-    def _load_itempic_pixmap(itempic: Path) -> QPixmap:
-        cache_key = (itempic, itempic.stat().st_mtime)
-        pixmap = ManageKeybladesDialog._itempic_pixmap_cache.get(cache_key)
-        if pixmap is None:
-            with Image.open(itempic) as image:
-                pixmap = image.resize((48, 48)).toqpixmap()
-            ManageKeybladesDialog._itempic_pixmap_cache[cache_key] = pixmap
-        return pixmap
-
     @staticmethod
     def _refresh_keyblade_info(grid: QGridLayout, keyblades: list[ReplacementKeyblade]):
-        add_widget = grid.addWidget
         for row, keyblade in enumerate(keyblades):
-            itempic = keyblade.remastered_itempic()
+            itempic_thumbnail = keyblade.itempic_thumbnail()
             itempic_label = QLabel("")
             itempic_label.setFixedSize(QSize(48, 48))
-            if itempic:
-                itempic_label.setPixmap(ManageKeybladesDialog._load_itempic_pixmap(itempic))
+            if itempic_thumbnail:
+                with Image.open(itempic_thumbnail) as image:
+                    itempic_label.setPixmap(image.resize((48, 48)).toqpixmap())
 
             name_label = QLabel(keyblade.name)
             author_label = QLabel(keyblade.author)


### PR DESCRIPTION
Something got slower with the loading of the actual itempic files with the Python update. Instead of loading the actual itempics which are usually large .dds files, just create small .png thumbnails and display those.

Thumbnails are created when importing keyblades, or on demand if missing to support already-imported keyblades.