### PR TITLE
Fix AppImage release upload repository

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -85,4 +85,5 @@ jobs:
       - name: Attach to release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release upload '${{ github.event.release.tag_name }}' KH2.Randomizer-x86_64.AppImage --clobber


### PR DESCRIPTION
## Summary
- provide \`GH_REPO\` to the GitHub CLI release upload step
- allow the release job to identify \`tommadness/KH2Randomizer\` without a checkout or local Git remote

## Root cause
The release job only downloads the built artifact. Since it does not check out the repository, \`gh release upload\` failed while trying to infer the repository from Git, reporting \`fatal: not a git repository\`.

## Validation
- \`git diff --check\` passes
- the value comes from the built-in \`github.repository\` context, so it remains correct when the workflow runs in a fork