### PR TITLE
Replace Pyperclip with Qt's native clipboard API for all GUI clipboard operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ python -m venv .venv
 
 Runtime notes:
 
-- Copying seed strings to the clipboard needs a clipboard utility: `wl-clipboard`
-  on Wayland or `xclip`/`xsel` on X11.
 - Some distributions need Qt's xcb runtime libraries for PySide6 (for example,
   `libxcb-cursor0` on Debian/Ubuntu).
 - Cosmetics features that use the OpenKH tools (keyblade randomization, texture


### PR DESCRIPTION
## Summary

SteamOS does not include `wl-clipboard` by default. Pyperclip relies on external utilities such as `wl-copy` and `wl-paste` under Wayland, which causes clipboard operations to fail on a default SteamOS installation. Since the application already uses PySide6, Qt can provide native clipboard integration across Wayland, X11, and Windows without requiring a separate clipboard package or command-line utility.

## Changes

- Added shared Qt clipboard helpers for copying and retrieving text.
- Migrated seed string copy and paste operations to the Qt clipboard.
- Migrated progression point CSV copy and paste operations to the Qt clipboard.
- Removed the Pyperclip dependency.
- Updated the Linux documentation to clarify that external clipboard utilities are not required.
- Added focused tests for Qt clipboard text round-tripping and removal of Pyperclip from migrated files.

## Impacts

- **SteamOS & other Distros using Wayland:** No longer requires `wl-clipboard`.
- **X11 Linux Distributions:** No longer requires `xclip` or `xsel`.
- **Windows:** Qt uses the native Windows clipboard API.

This is purely a backend change to how copying to clipboard is done, none of the formatting & other operations are affected.

## Tests before Merge


- [X] Confirm all Copy operations works
- [X] Confirm Copying works on Linux in general
- [ ] Confirm Copying works on SteamOS (In Progress)
- [ ] Confirm Copying works on Windows
